### PR TITLE
🔧 update localhost proxy and avoid buildx

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
-TAG=dev-22.9.5-SNAPSHOT-scenarios-v0
+TAG=22.9.4.1-ARKEA
 MONGO=6.0.2
 PLATFORM=

--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
-TAG=22.9.4
+TAG=dev-22.9.5-SNAPSHOT-scenarios-v0
 MONGO=6.0.2
 PLATFORM=

--- a/bot-admin-open-data/pom.xml
+++ b/bot-admin-open-data/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>ai.tock</groupId>
         <artifactId>tock-docker</artifactId>
-        <version>dev-22.9.5-SNAPSHOT-scenarios-v0</version>
+        <version>22.9.4.1-ARKEA</version>
     </parent>
 
     <artifactId>tock-docker-bot-admin-open-data</artifactId>
@@ -108,12 +108,7 @@
                                     <tag>${latest}</tag>
                                     <tag>${project.version}</tag>
                                 </tags>
-                                <buildx>
-                                    <platforms>
-                                        <platform>linux/amd64</platform>
-                                        <platform>linux/arm64</platform>
-                                    </platforms>
-                                </buildx>
+                       
                             </build>
                             <run>
                                 <ports>

--- a/bot-admin-open-data/pom.xml
+++ b/bot-admin-open-data/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>ai.tock</groupId>
         <artifactId>tock-docker</artifactId>
-        <version>22.9.5-SNAPSHOT</version>
+        <version>dev-22.9.5-SNAPSHOT-scenarios-v0</version>
     </parent>
 
     <artifactId>tock-docker-bot-admin-open-data</artifactId>

--- a/bot-admin/pom.xml
+++ b/bot-admin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>ai.tock</groupId>
         <artifactId>tock-docker</artifactId>
-        <version>22.9.5-SNAPSHOT</version>
+        <version>dev-22.9.5-SNAPSHOT-scenarios-v0</version>
     </parent>
 
     <artifactId>tock-docker-bot-admin</artifactId>

--- a/bot-admin/pom.xml
+++ b/bot-admin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>ai.tock</groupId>
         <artifactId>tock-docker</artifactId>
-        <version>dev-22.9.5-SNAPSHOT-scenarios-v0</version>
+        <version>22.9.4.1-ARKEA</version>
     </parent>
 
     <artifactId>tock-docker-bot-admin</artifactId>
@@ -109,13 +109,7 @@
                                     <tag>${major}</tag>
                                     <tag>${latest}</tag>
                                     <tag>${project.version}</tag>
-                                </tags>
-                                <buildx>
-                                    <platforms>
-                                        <platform>linux/amd64</platform>
-                                        <platform>linux/arm64</platform>
-                                    </platforms>
-                                </buildx>
+                                </tags>                    
                             </build>
                             <run>
                                 <ports>

--- a/bot-api-webhook/pom.xml
+++ b/bot-api-webhook/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>ai.tock</groupId>
         <artifactId>tock-docker</artifactId>
-        <version>dev-22.9.5-SNAPSHOT-scenarios-v0</version>
+        <version>22.9.4.1-ARKEA</version>
     </parent>
 
     <artifactId>tock-docker-bot-api-webhook</artifactId>
@@ -70,13 +70,7 @@
                                     <tag>${major}</tag>
                                     <tag>${latest}</tag>
                                     <tag>${project.version}</tag>
-                                </tags>
-                                <buildx>
-                                    <platforms>
-                                        <platform>linux/amd64</platform>
-                                        <platform>linux/arm64</platform>
-                                    </platforms>
-                                </buildx>
+                                </tags>                 
                             </build>
                             <run>
                                 <ports>

--- a/bot-api-webhook/pom.xml
+++ b/bot-api-webhook/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>ai.tock</groupId>
         <artifactId>tock-docker</artifactId>
-        <version>22.9.5-SNAPSHOT</version>
+        <version>dev-22.9.5-SNAPSHOT-scenarios-v0</version>
     </parent>
 
     <artifactId>tock-docker-bot-api-webhook</artifactId>

--- a/bot-api/pom.xml
+++ b/bot-api/pom.xml
@@ -23,11 +23,15 @@
     <parent>
         <groupId>ai.tock</groupId>
         <artifactId>tock-docker</artifactId>
-        <version>22.9.5-SNAPSHOT</version>
+        <version>dev-22.9.5-SNAPSHOT-scenarios-v0</version>
     </parent>
 
     <artifactId>tock-docker-bot-api</artifactId>
     <packaging>pom</packaging>
+
+    <properties>
+        <dialog-manager>tock-bot-dialog-manager-core-${project.version}</dialog-manager>
+    </properties>
 
     <dependencies>
         <dependency>
@@ -42,11 +46,16 @@
                 <groupId>io.fabric8</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
                 <configuration>
+                    <verbose>true</verbose>
                     <images>
                         <image>
                             <name>tock/bot_api:${project.version}</name>
                             <build>
-                                <from>openjdk:19</from>
+                                <args>
+                                    <https_proxy>${env.HTTPS_PROXY}</https_proxy>
+                                    <http_proxy>${env.HTTP_PROXY}</http_proxy>
+                                </args>
+                                <from>python:3.8-slim-buster</from>
                                 <assembly>
                                     <inline>
                                         <dependencySets>
@@ -63,6 +72,30 @@
                                         </files>
                                     </inline>
                                 </assembly>
+                                <shell>
+                                    <arg>/bin/bash</arg>
+                                    <arg>-c</arg>
+                                </shell>
+                                <env>
+                                    <JAVA_HOME>/usr/lib/jvm/jdk-19</JAVA_HOME>
+                                </env>
+                                <runCmds>
+
+                                    <run>apt-get update </run>
+                                    <run>apt-get -qq install -y curl wget gcc unzip graphviz</run>
+
+                                    <!-- TODO : use aws corretto jdk 19 -->
+                                    <!--run>wget https://corretto.aws/downloads/latest/amazon-corretto-19-x64-linux-jdk.tar.gz</run-->
+                                    <run>wget https://download.oracle.com/java/19/latest/jdk-19_linux-x64_bin.deb</run>
+                                    <run>apt-get -qqy install ./jdk-19_linux-x64_bin.deb</run>
+                                    <run>update-alternatives --install /usr/bin/java java /usr/lib/jvm/jdk-19/bin/java 1919</run>
+
+                                    <run>unzip /maven/${dialog-manager}.jar -d /maven/${dialog-manager}</run>
+                                    <run>mv /maven/${dialog-manager}/python /tmp</run>
+                                    <run>rm -r /maven/${dialog-manager}</run>
+                                    <run>pip3 install -r /tmp/python/install/requirements.txt</run>
+                                    <run>mkdir /tmp/python/log</run>
+                                </runCmds>
                                 <cmd>
                                     <shell>java $JAVA_ARGS -Dfile.encoding=UTF-8 -Dlogback.configurationFile='file:///maven/logback.xml' -cp '/maven/*' ai.tock.bot.api.service.StartBotApiKt</shell>
                                 </cmd>
@@ -71,12 +104,6 @@
                                     <tag>${latest}</tag>
                                     <tag>${project.version}</tag>
                                 </tags>
-                                <buildx>
-                                    <platforms>
-                                        <platform>linux/amd64</platform>
-                                        <platform>linux/arm64</platform>
-                                    </platforms>
-                                </buildx>
                             </build>
                             <run>
                                 <ports>

--- a/bot-api/pom.xml
+++ b/bot-api/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>ai.tock</groupId>
         <artifactId>tock-docker</artifactId>
-        <version>dev-22.9.5-SNAPSHOT-scenarios-v0</version>
+        <version>22.9.4.1-ARKEA</version>
     </parent>
 
     <artifactId>tock-docker-bot-api</artifactId>
@@ -56,6 +56,8 @@
                                     <http_proxy>${env.HTTP_PROXY}</http_proxy>
                                 </args>
                                 <from>python:3.8-slim-buster</from>
+                                <!-- network as host is useful when using proxy in localhost-->
+                                <!-- <network>host</network> -->
                                 <assembly>
                                     <inline>
                                         <dependencySets>

--- a/bot-open-data/pom.xml
+++ b/bot-open-data/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>ai.tock</groupId>
         <artifactId>tock-docker</artifactId>
-        <version>22.9.5-SNAPSHOT</version>
+        <version>dev-22.9.5-SNAPSHOT-scenarios-v0</version>
     </parent>
 
     <artifactId>tock-docker-bot-open-data</artifactId>

--- a/bot-open-data/pom.xml
+++ b/bot-open-data/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>ai.tock</groupId>
         <artifactId>tock-docker</artifactId>
-        <version>dev-22.9.5-SNAPSHOT-scenarios-v0</version>
+        <version>22.9.4.1-ARKEA</version>
     </parent>
 
     <artifactId>tock-docker-bot-open-data</artifactId>
@@ -70,13 +70,7 @@
                                     <tag>${major}</tag>
                                     <tag>${latest}</tag>
                                     <tag>${project.version}</tag>
-                                </tags>
-                                <buildx>
-                                    <platforms>
-                                        <platform>linux/amd64</platform>
-                                        <platform>linux/arm64</platform>
-                                    </platforms>
-                                </buildx>
+                                </tags>                     
                             </build>
                             <run>
                                 <ports>

--- a/docker-compose-bot-frontend.yml
+++ b/docker-compose-bot-frontend.yml
@@ -156,9 +156,9 @@ services:
       - tock_nlp_service_url=http://nlp_api:8080
       - tock_env=integ
       - tock_websocket_enabled=true
-     - tock_default_log_level=warn
-     - tock_service_log_level=info
-     - tock_database_log_level=warn
+      - tock_default_log_level=warn
+      - tock_service_log_level=info
+      - tock_database_log_level=warn
     ports:
       - "8080:8080"
 

--- a/docker-compose-bot-frontend.yml
+++ b/docker-compose-bot-frontend.yml
@@ -107,7 +107,6 @@ services:
 #      - tock_default_log_level=warn
 #      - tock_service_log_level=info
 #      - tock_database_log_level=warn
-      - botadminverticle_body_limit=-1
       - tock_bot_rest_client_request_timeout_ms=500000000
       - tock_bot_api_timeout_in_ms=500000000
       - tock_api_timout_in_s=600

--- a/docker-compose-bot-frontend.yml
+++ b/docker-compose-bot-frontend.yml
@@ -97,7 +97,7 @@ services:
     environment:
       - tock_mongo_url=mongodb://mongo:27017,mongo2:27018,mongo3:27019/?replicaSet=tock
       - nlp_duckling_url=http://duckling:8080
-      - tock_env=prod
+      - tock_env=dev
       - tock_bot_admin_rest_default_base_url=http://bot_api:8080
       - tock_bot_compiler_service_url=http://kotlin_compiler:8080
       - tock_configuration_bot_default_base_url=http://bot_api:8080

--- a/docker-compose-bot-frontend.yml
+++ b/docker-compose-bot-frontend.yml
@@ -1,0 +1,168 @@
+version: '3'
+
+services:
+
+  mongo:
+    image: "${PLATFORM}mongo:${MONGO}"
+    volumes:
+      - front-tockmongo:/data/db
+    ports:
+      - "27017:27017"
+    command: --bind_ip_all --port 27017 --replSet "tock"
+
+  mongo2:
+    image: "${PLATFORM}mongo:${MONGO}"
+    depends_on:
+      - mongo
+    volumes:
+      - front-tockmongo2:/data/db
+    ports:
+      - "27018:27018"
+    command: --bind_ip_all --port 27018 --replSet "tock"
+
+  mongo3:
+    image: "${PLATFORM}mongo:${MONGO}"
+    depends_on:
+      - mongo
+      - mongo2
+    volumes:
+      - front-tockmongo3:/data/db
+    ports:
+      - "27019:27019"
+    command: --bind_ip_all --port 27019 --replSet "tock"
+
+  mongo-setup:
+    container_name: "mongo-setup-frontend"
+    image: "${PLATFORM}mongo:${MONGO}"
+    depends_on:
+      - "mongo"
+      - "mongo2"
+      - "mongo3"
+    links:
+      - mongo:mongo
+      - mongo2:mongo2
+      - mongo3:mongo3
+    volumes:
+      - ./scripts:/scripts
+    environment:
+      - MONGO1=mongo
+      - MONGO2=mongo2
+      - MONGO3=mongo3
+      - RS=tock
+    entrypoint: [ "/scripts/setup.sh" ]
+
+  build_worker:
+    image: "${PLATFORM}tock/build_worker:${TAG}"
+    depends_on:
+      - mongo
+      - mongo2
+      - mongo3
+    environment:
+      - tock_mongo_url=mongodb://mongo:27017,mongo2:27018,mongo3:27019/?replicaSet=tock
+      - tock_env=prod
+      - JAVA_ARGS=-Xmx1g -XX:MaxMetaspaceSize=256m
+#      - tock_default_log_level=warn
+#      - tock_service_log_level=info
+#      - tock_database_log_level=warn
+
+  duckling:
+    image: "${PLATFORM}tock/duckling:${TAG}"
+    environment:
+      - tock_env=prod
+#      - tock_default_log_level=warn
+#      - tock_service_log_level=info
+#      - tock_database_log_level=warn
+    expose:
+      - "8080"
+
+  kotlin_compiler:
+    image: "${PLATFORM}tock/kotlin_compiler:${TAG}"
+    environment:
+      - tock_env=prod
+      - tock_kotlin_compiler_classpath=/maven
+#      - tock_default_log_level=warn
+#      - tock_service_log_level=info
+#      - tock_database_log_level=warn
+    expose:
+      - "8080"
+
+  admin_web:
+    image: "${PLATFORM}tock/bot_admin:${TAG}"
+    depends_on:
+      - mongo
+      - mongo2
+      - mongo3
+      - duckling
+      - kotlin_compiler
+    environment:
+      - tock_mongo_url=mongodb://mongo:27017,mongo2:27018,mongo3:27019/?replicaSet=tock
+      - nlp_duckling_url=http://duckling:8080
+      - tock_env=prod
+      - tock_bot_admin_rest_default_base_url=http://bot_api:8080
+      - tock_bot_compiler_service_url=http://kotlin_compiler:8080
+      - tock_configuration_bot_default_base_url=http://bot_api:8080
+      #remove this in production
+      - tock_https_env=false
+      - botadminverticle_body_limit=-1
+#      - tock_default_log_level=warn
+#      - tock_service_log_level=info
+#      - tock_database_log_level=warn
+      - botadminverticle_body_limit=-1
+      - tock_bot_rest_client_request_timeout_ms=500000000
+      - tock_bot_api_timeout_in_ms=500000000
+      - tock_api_timout_in_s=600
+      - tock_bot_test_timeout_in_ms=500000000
+      - 'tock_users=admin@app.com,nlpuser@arkea.com,botuser@arkea.com,admin@arkea.com,techadmin@arkea.com,user1@arkea.com,user2@arkea.com,nlpOnly@arkea.com,botOnly@arkea.com,faqNlpOnly@arkea.com,faqBotOnly@arkea.com'
+      - 'tock_passwords=password,pwd,pwd,pwd,pwd,pwd,pwd,pwd,pwd,pwd,pwd'
+      - 'tock_organizations=app,app,app,abei,abei,app,app,app,app,app,app'
+      - 'tock_roles=faqNlpUser|faqBotUser|nlpUser|botUser|admin|technicalAdmin,nlpUser|botUser,nlpUser|botUser,admin,nlpUser|botUser|admin|technicalAdmin,nlpUser|botUser,nlpUser|botUser,nlpUser,botUser,faqNlpUser,faqNlpUser|faqBotUser'
+      - tock_encrypt_pass=PWD123
+      - tock_default_log_level=debug
+    ports:
+      - '7999:8080'
+
+  nlp_api:
+    image: "${PLATFORM}tock/nlp_api:${TAG}"
+    depends_on:
+      - mongo
+      - mongo2
+      - mongo3
+      - duckling
+    environment:
+      - tock_mongo_url=mongodb://mongo:27017,mongo2:27018,mongo3:27019/?replicaSet=tock
+      - nlp_duckling_url=http://duckling:8080
+      - tock_env=prod
+      - tock_web_use_default_cors_handler=true
+      - tock_web_use_default_cors_handler_with_credentials=false
+      - tock_web_use_default_cors_handler_url=*
+#      - tock_default_log_level=warn
+#      - tock_service_log_level=info
+#      - tock_database_log_level=warn
+      - tock_encrypt_pass=PWD123
+      - tock_default_log_level=debug
+    ports:
+      - "8888:8080"
+
+  bot_api:
+    image: "${PLATFORM}tock/bot_api:${TAG}"
+    depends_on:
+      - mongo
+      - mongo2
+      - mongo3
+      - nlp_api
+    environment:
+      - JAVA_ARGS=-Djava.library.path=/usr/local/lib/python3.8/site-packages/jep
+      - tock_mongo_url=mongodb://mongo:27017,mongo2:27018,mongo3:27019/?replicaSet=tock
+      - tock_nlp_service_url=http://nlp_api:8080
+      - tock_env=integ
+      - tock_websocket_enabled=true
+     - tock_default_log_level=warn
+     - tock_service_log_level=info
+     - tock_database_log_level=warn
+    ports:
+      - "8080:8080"
+
+volumes:
+  front-tockmongo:
+  front-tockmongo2:
+  front-tockmongo3:

--- a/docker-compose-bot-python.yml
+++ b/docker-compose-bot-python.yml
@@ -52,7 +52,7 @@ services:
     entrypoint: [ "/scripts/setup.sh" ]
 
   build_worker:
-    image: "tock/build_worker:${TAG}"
+    image: "${PLATFORM}tock/build_worker:${TAG}"
     depends_on:
       - mongo
       - mongo2
@@ -66,7 +66,7 @@ services:
 #      - tock_database_log_level=warn
 
   duckling:
-    image: "tock/duckling:${TAG}"
+    image: "${PLATFORM}tock/duckling:${TAG}"
     environment:
       - tock_env=prod
 #      - tock_default_log_level=warn
@@ -76,7 +76,7 @@ services:
       - "8080"
 
   kotlin_compiler:
-    image: "tock/kotlin_compiler:${TAG}"
+    image: "${PLATFORM}tock/kotlin_compiler:${TAG}"
     environment:
       - tock_env=prod
       - tock_kotlin_compiler_classpath=/maven
@@ -87,7 +87,7 @@ services:
       - "8080"
 
   admin_web:
-    image: "tock/bot_admin:${TAG}"
+    image: "${PLATFORM}tock/bot_admin:${TAG}"
     depends_on:
       - mongo
       - mongo2
@@ -111,7 +111,7 @@ services:
       - "80:8080"
 
   nlp_api:
-    image: "tock/nlp_api:${TAG}"
+    image: "${PLATFORM}tock/nlp_api:${TAG}"
     depends_on:
       - mongo
       - mongo2
@@ -131,7 +131,7 @@ services:
       - "8888:8080"
 
   bot_api:
-    image: "tock/bot_api:${TAG}"
+    image: "${PLATFORM}tock/bot_api:${TAG}"
     depends_on:
       - mongo
       - mongo2

--- a/docker-compose-bot-python.yml
+++ b/docker-compose-bot-python.yml
@@ -1,0 +1,155 @@
+version: '3'
+
+services:
+
+  mongo:
+    image: "${PLATFORM}mongo:${MONGO}"
+    volumes:
+      - tockmongo:/data/db
+    ports:
+      - "27017:27017"
+    command: --bind_ip_all --port 27017 --replSet "tock"
+
+  mongo2:
+    image: "${PLATFORM}mongo:${MONGO}"
+    depends_on:
+      - mongo
+    volumes:
+      - tockmongo2:/data/db
+    ports:
+      - "27018:27018"
+    command: --bind_ip_all --port 27018 --replSet "tock"
+
+  mongo3:
+    image: "${PLATFORM}mongo:${MONGO}"
+    depends_on:
+      - mongo
+      - mongo2
+    volumes:
+      - tockmongo3:/data/db
+    ports:
+      - "27019:27019"
+    command: --bind_ip_all --port 27019 --replSet "tock"
+
+  mongo-setup:
+    container_name: "mongo-setup"
+    image: "${PLATFORM}mongo:${MONGO}"
+    depends_on:
+      - "mongo"
+      - "mongo2"
+      - "mongo3"
+    links:
+      - mongo:mongo
+      - mongo2:mongo2
+      - mongo3:mongo3
+    volumes:
+      - ./scripts:/scripts
+    environment:
+      - MONGO1=mongo
+      - MONGO2=mongo2
+      - MONGO3=mongo3
+      - RS=tock
+    entrypoint: [ "/scripts/setup.sh" ]
+
+  build_worker:
+    image: "tock/build_worker:${TAG}"
+    depends_on:
+      - mongo
+      - mongo2
+      - mongo3
+    environment:
+      - tock_mongo_url=mongodb://mongo:27017,mongo2:27018,mongo3:27019/?replicaSet=tock
+      - tock_env=prod
+      - JAVA_ARGS=-Xmx1g -XX:MaxMetaspaceSize=256m
+#      - tock_default_log_level=warn
+#      - tock_service_log_level=info
+#      - tock_database_log_level=warn
+
+  duckling:
+    image: "tock/duckling:${TAG}"
+    environment:
+      - tock_env=prod
+#      - tock_default_log_level=warn
+#      - tock_service_log_level=info
+#      - tock_database_log_level=warn
+    expose:
+      - "8080"
+
+  kotlin_compiler:
+    image: "tock/kotlin_compiler:${TAG}"
+    environment:
+      - tock_env=prod
+      - tock_kotlin_compiler_classpath=/maven
+#      - tock_default_log_level=warn
+#      - tock_service_log_level=info
+#      - tock_database_log_level=warn
+    expose:
+      - "8080"
+
+  admin_web:
+    image: "tock/bot_admin:${TAG}"
+    depends_on:
+      - mongo
+      - mongo2
+      - mongo3
+      - duckling
+      - kotlin_compiler
+    environment:
+      - tock_mongo_url=mongodb://mongo:27017,mongo2:27018,mongo3:27019/?replicaSet=tock
+      - nlp_duckling_url=http://duckling:8080
+      - tock_env=prod
+      - tock_bot_admin_rest_default_base_url=http://bot_api:8080
+      - tock_bot_compiler_service_url=http://kotlin_compiler:8080
+      - tock_configuration_bot_default_base_url=http://bot_api:8080
+      #remove this in production
+      - tock_https_env=false
+      - botadminverticle_body_limit=-1
+#      - tock_default_log_level=warn
+#      - tock_service_log_level=info
+#      - tock_database_log_level=warn
+    ports:
+      - "80:8080"
+
+  nlp_api:
+    image: "tock/nlp_api:${TAG}"
+    depends_on:
+      - mongo
+      - mongo2
+      - mongo3
+      - duckling
+    environment:
+      - tock_mongo_url=mongodb://mongo:27017,mongo2:27018,mongo3:27019/?replicaSet=tock
+      - nlp_duckling_url=http://duckling:8080
+      - tock_env=prod
+      - tock_web_use_default_cors_handler=true
+      - tock_web_use_default_cors_handler_with_credentials=false
+      - tock_web_use_default_cors_handler_url=*
+#      - tock_default_log_level=warn
+#      - tock_service_log_level=info
+#      - tock_database_log_level=warn
+    ports:
+      - "8888:8080"
+
+  bot_api:
+    image: "tock/bot_api:${TAG}"
+    depends_on:
+      - mongo
+      - mongo2
+      - mongo3
+      - nlp_api
+    environment:
+      - JAVA_ARGS=-Djava.library.path=/usr/local/lib/python3.8/site-packages/jep
+      - tock_mongo_url=mongodb://mongo:27017,mongo2:27018,mongo3:27019/?replicaSet=tock
+      - tock_nlp_service_url=http://nlp_api:8080
+      - tock_env=integ
+      - tock_websocket_enabled=true
+#      - tock_default_log_level=warn
+#      - tock_service_log_level=info
+#      - tock_database_log_level=warn
+    ports:
+      - "8080:8080"
+
+volumes:
+  tockmongo:
+  tockmongo2:
+  tockmongo3:

--- a/duckling/pom.xml
+++ b/duckling/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>ai.tock</groupId>
         <artifactId>tock-docker</artifactId>
-        <version>dev-22.9.5-SNAPSHOT-scenarios-v0</version>
+        <version>22.9.4.1-ARKEA</version>
     </parent>
 
     <artifactId>tock-docker-duckling</artifactId>
@@ -74,13 +74,7 @@
                                     <tag>${major}</tag>
                                     <tag>${latest}</tag>
                                     <tag>${project.version}</tag>
-                                </tags>
-                                <buildx>
-                                    <platforms>
-                                        <platform>linux/amd64</platform>
-                                        <platform>linux/arm64</platform>
-                                    </platforms>
-                                </buildx>
+                                </tags>                     
                             </build>
                             <run>
                                 <ports>

--- a/duckling/pom.xml
+++ b/duckling/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>ai.tock</groupId>
         <artifactId>tock-docker</artifactId>
-        <version>22.9.5-SNAPSHOT</version>
+        <version>dev-22.9.5-SNAPSHOT-scenarios-v0</version>
     </parent>
 
     <artifactId>tock-docker-duckling</artifactId>

--- a/kotlin-compiler/pom.xml
+++ b/kotlin-compiler/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>ai.tock</groupId>
         <artifactId>tock-docker</artifactId>
-        <version>22.9.5-SNAPSHOT</version>
+        <version>dev-22.9.5-SNAPSHOT-scenarios-v0</version>
     </parent>
 
     <artifactId>tock-docker-kotlin-compiler</artifactId>

--- a/kotlin-compiler/pom.xml
+++ b/kotlin-compiler/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>ai.tock</groupId>
         <artifactId>tock-docker</artifactId>
-        <version>dev-22.9.5-SNAPSHOT-scenarios-v0</version>
+        <version>22.9.4.1-ARKEA</version>
     </parent>
 
     <artifactId>tock-docker-kotlin-compiler</artifactId>
@@ -72,13 +72,7 @@
                                     <tag>${major}</tag>
                                     <tag>${latest}</tag>
                                     <tag>${project.version}</tag>
-                                </tags>
-                                <buildx>
-                                    <platforms>
-                                        <platform>linux/amd64</platform>
-                                        <platform>linux/arm64</platform>
-                                    </platforms>
-                                </buildx>
+                                </tags>                    
                             </build>
                             <run>
                                 <ports>

--- a/nlp-admin/pom.xml
+++ b/nlp-admin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>ai.tock</groupId>
         <artifactId>tock-docker</artifactId>
-        <version>22.9.5-SNAPSHOT</version>
+        <version>dev-22.9.5-SNAPSHOT-scenarios-v0</version>
     </parent>
 
     <artifactId>tock-docker-nlp-admin</artifactId>

--- a/nlp-admin/pom.xml
+++ b/nlp-admin/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>ai.tock</groupId>
         <artifactId>tock-docker</artifactId>
-        <version>dev-22.9.5-SNAPSHOT-scenarios-v0</version>
+        <version>22.9.4.1-ARKEA</version>
     </parent>
 
     <artifactId>tock-docker-nlp-admin</artifactId>
@@ -105,13 +105,7 @@
                                     <tag>${major}</tag>
                                     <tag>${latest}</tag>
                                     <tag>${project.version}</tag>
-                                </tags>
-                                <buildx>
-                                    <platforms>
-                                        <platform>linux/amd64</platform>
-                                        <platform>linux/arm64</platform>
-                                    </platforms>
-                                </buildx>
+                                </tags>                   
                             </build>
                             <run>
                                 <ports>

--- a/nlp-api/pom.xml
+++ b/nlp-api/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>ai.tock</groupId>
         <artifactId>tock-docker</artifactId>
-        <version>22.9.5-SNAPSHOT</version>
+        <version>dev-22.9.5-SNAPSHOT-scenarios-v0</version>
     </parent>
 
     <artifactId>tock-docker-nlp-api</artifactId>

--- a/nlp-api/pom.xml
+++ b/nlp-api/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>ai.tock</groupId>
         <artifactId>tock-docker</artifactId>
-        <version>dev-22.9.5-SNAPSHOT-scenarios-v0</version>
+        <version>22.9.4.1-ARKEA</version>
     </parent>
 
     <artifactId>tock-docker-nlp-api</artifactId>
@@ -78,13 +78,7 @@
                                     <tag>${major}</tag>
                                     <tag>${latest}</tag>
                                     <tag>${project.version}</tag>
-                                </tags>
-                                <buildx>
-                                    <platforms>
-                                        <platform>linux/amd64</platform>
-                                        <platform>linux/arm64</platform>
-                                    </platforms>
-                                </buildx>
+                                </tags>                     
                             </build>
                             <run>
                                 <ports>

--- a/nlp-build-model-worker/pom.xml
+++ b/nlp-build-model-worker/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>ai.tock</groupId>
         <artifactId>tock-docker</artifactId>
-        <version>22.9.5-SNAPSHOT</version>
+        <version>dev-22.9.5-SNAPSHOT-scenarios-v0</version>
     </parent>
 
     <artifactId>tock-docker-nlp-build-model-worker</artifactId>

--- a/nlp-build-model-worker/pom.xml
+++ b/nlp-build-model-worker/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>ai.tock</groupId>
         <artifactId>tock-docker</artifactId>
-        <version>dev-22.9.5-SNAPSHOT-scenarios-v0</version>
+        <version>22.9.4.1-ARKEA</version>
     </parent>
 
     <artifactId>tock-docker-nlp-build-model-worker</artifactId>
@@ -82,13 +82,7 @@
                                     <tag>${major}</tag>
                                     <tag>${latest}</tag>
                                     <tag>${project.version}</tag>
-                                </tags>
-                                <buildx>
-                                    <platforms>
-                                        <platform>linux/amd64</platform>
-                                        <platform>linux/arm64</platform>
-                                    </platforms>
-                                </buildx>
+                                </tags>            
                             </build>
                             <run>
                                 <log>

--- a/pom.xml
+++ b/pom.xml
@@ -22,14 +22,14 @@
 
     <groupId>ai.tock</groupId>
     <artifactId>tock-docker</artifactId>
-    <version>22.9.5-SNAPSHOT</version>
+    <version>dev-22.9.5-SNAPSHOT-scenarios-v0</version>
     <packaging>pom</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <major>22.9-SNAPSHOT</major>
         <latest>latest-SNAPSHOT</latest>
-        <tock>22.9.4</tock>
+        <version>dev-22.9.5-SNAPSHOT-scenarios-v0</version>
         <bot-open-data>22.9.4</bot-open-data>
         <stanford>22.9.4</stanford>
         <demo>22.9.0</demo>

--- a/pom.xml
+++ b/pom.xml
@@ -22,14 +22,14 @@
 
     <groupId>ai.tock</groupId>
     <artifactId>tock-docker</artifactId>
-    <version>dev-22.9.5-SNAPSHOT-scenarios-v0</version>
+    <version>22.9.4.1-ARKEA</version>
     <packaging>pom</packaging>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <major>22.9-SNAPSHOT</major>
         <latest>latest-SNAPSHOT</latest>
-        <version>dev-22.9.5-SNAPSHOT-scenarios-v0</version>
+        <version>22.9.4</version>
         <bot-open-data>22.9.4</bot-open-data>
         <stanford>22.9.4</stanford>
         <demo>22.9.0</demo>


### PR DESCRIPTION
Changes to 
- avoid trouble when mvn package docker:build with <buildx>
- make usable a local proxy with the use of <network><network> in botApi when docker build to be able to use apt install (it is in comment for now)